### PR TITLE
I2b2annotator

### DIFF
--- a/biomedicus-core/pom.xml
+++ b/biomedicus-core/pom.xml
@@ -41,6 +41,11 @@
             <artifactId>snakeyaml</artifactId>
             <version>1.15</version>
         </dependency>
+        <dependency>
+            <groupId>nz.ac.waikato.cms.weka</groupId>
+            <artifactId>weka-stable</artifactId>
+            <version>3.8.0</version>
+        </dependency>
     </dependencies>
     
 </project>

--- a/biomedicus-core/src/main/java/edu/umn/biomedicus/docclass/DocumentClassifier.java
+++ b/biomedicus-core/src/main/java/edu/umn/biomedicus/docclass/DocumentClassifier.java
@@ -1,0 +1,33 @@
+package edu.umn.biomedicus.docclass;
+
+import com.google.inject.Inject;
+
+import edu.umn.biomedicus.annotations.DocumentScoped;
+import edu.umn.biomedicus.annotations.Setting;
+import edu.umn.biomedicus.application.DocumentProcessor;
+import edu.umn.biomedicus.common.text.Document;
+import edu.umn.biomedicus.exc.BiomedicusException;
+
+/**
+ * Classifies documents using a DocumentClassifierModel
+ *
+ * Created by gpfinley on 7/28/16.
+ */
+@DocumentScoped
+public class DocumentClassifier implements DocumentProcessor {
+
+    private final DocumentClassifierModel model;
+    private final Document document;
+
+    @Inject
+    public DocumentClassifier(@Setting("docclass.model") DocumentClassifierModel model, Document document) throws BiomedicusException {
+        this.model = model;
+        this.document = document;
+    }
+
+    @Override
+    public void process() throws BiomedicusException {
+        document.setMetadata(model.getMetadataKey(), model.predict(document));
+    }
+
+}

--- a/biomedicus-core/src/main/java/edu/umn/biomedicus/docclass/DocumentClassifierModel.java
+++ b/biomedicus-core/src/main/java/edu/umn/biomedicus/docclass/DocumentClassifierModel.java
@@ -1,0 +1,27 @@
+package edu.umn.biomedicus.docclass;
+
+import edu.umn.biomedicus.common.text.Document;
+import edu.umn.biomedicus.exc.BiomedicusException;
+
+/**
+ * Generic interface for document classification
+ *
+ * Created by gpfinley on 8/4/16.
+ */
+public interface DocumentClassifierModel {
+
+    /**
+     * Return the hypothesized class for this document
+     * @param document the document
+     * @return a String identifying the class
+     * @throws BiomedicusException
+     */
+    String predict(Document document) throws BiomedicusException;
+
+    /**
+     * Return the key for metadata (how document classes are stored)
+     * @return the name of this classification type
+     */
+    String getMetadataKey();
+
+}

--- a/biomedicus-core/src/main/java/edu/umn/biomedicus/docclass/SeverityClassifierModel.java
+++ b/biomedicus-core/src/main/java/edu/umn/biomedicus/docclass/SeverityClassifierModel.java
@@ -1,0 +1,110 @@
+package edu.umn.biomedicus.docclass;
+
+import com.google.inject.Inject;
+import com.google.inject.ProvidedBy;
+import com.google.inject.Singleton;
+import edu.umn.biomedicus.annotations.Setting;
+import edu.umn.biomedicus.application.DataLoader;
+import edu.umn.biomedicus.common.text.Document;
+import edu.umn.biomedicus.exc.BiomedicusException;
+import weka.classifiers.Classifier;
+import weka.core.Instance;
+import weka.filters.Filter;
+
+import java.io.*;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Classify documents based on symptom severity
+ * Uses a Weka classifier with attribute selection
+ *
+ * Created by gpfinley on 7/28/16.
+ */
+@ProvidedBy(SeverityClassifierModel.Loader.class)
+public class SeverityClassifierModel implements DocumentClassifierModel, Serializable {
+
+    // For unknown classes (test data or poorly formatted training data)
+    protected static final String UNK = "unknown";
+
+    private final Classifier classifier;
+    private final Filter attSel;
+    private final TextWekaProcessor severityWekaProcessor;
+    private final String keyName = "Severity";
+
+    private final Map<Double, String> severityMap;
+
+    /**
+     * Initialize this model
+     * All training happens in the trainer; just store what we need to keep for classification
+     * @param classifier a Weka Classifier object
+     * @param attSel an attribute selection object
+     * @param severityWekaProcessor a processor to convert Document objects into Weka Instance objects
+     * @throws BiomedicusException
+     */
+    public SeverityClassifierModel(Classifier classifier, Filter attSel, TextWekaProcessor severityWekaProcessor) throws BiomedicusException {
+        severityMap = new HashMap<>();
+        severityMap.put(0., "ABSENT");
+        severityMap.put(1., "MILD");
+        severityMap.put(2., "MODERATE");
+        severityMap.put(3., "SEVERE");
+        severityMap.put(4., UNK);
+        this.classifier = classifier;
+        this.attSel = attSel;
+        this.severityWekaProcessor = severityWekaProcessor;
+    }
+
+    /**
+     * Perform attribute selection and then classification using the stored Weka objects
+     * @param document the document
+     * @return a string (from the predefined classes) representing this document's symptom severity
+     * @throws BiomedicusException
+     */
+    @Override
+    public String predict(Document document) throws BiomedicusException {
+        Instance inst = severityWekaProcessor.getTestData(document);
+        double result;
+        try {
+            if(attSel.input(inst)) {
+                inst = attSel.output();
+                result = classifier.classifyInstance(inst);
+            } else {
+                throw new Exception();
+            }
+        } catch(Exception e) {
+            throw new BiomedicusException();
+        }
+        return severityMap.get(result);
+    }
+
+    @Override
+    public String getMetadataKey() {
+        return keyName;
+    }
+
+    /**
+     * Load a serialized model
+     */
+    @Singleton
+    static class Loader extends DataLoader<SeverityClassifierModel> {
+
+        private final Path modelPath;
+
+        @Inject
+        public Loader(@Setting("docclass.severity.model.path") Path modelPath) {
+            this.modelPath = modelPath;
+        }
+
+        @Override
+        protected SeverityClassifierModel loadModel() throws BiomedicusException {
+            try {
+                ObjectInputStream ois = new ObjectInputStream(new FileInputStream(modelPath.toFile()));
+                return (SeverityClassifierModel) ois.readObject();
+            } catch(Exception e) {
+                throw new BiomedicusException();
+            }
+        }
+    }
+
+}

--- a/biomedicus-core/src/main/java/edu/umn/biomedicus/docclass/SeverityClassifierTrainer.java
+++ b/biomedicus-core/src/main/java/edu/umn/biomedicus/docclass/SeverityClassifierTrainer.java
@@ -1,0 +1,116 @@
+package edu.umn.biomedicus.docclass;
+
+import com.google.inject.Inject;
+import edu.umn.biomedicus.annotations.ProcessorScoped;
+import edu.umn.biomedicus.annotations.Setting;
+import edu.umn.biomedicus.application.CollectionProcessor;
+import edu.umn.biomedicus.common.text.Document;
+import edu.umn.biomedicus.exc.BiomedicusException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import weka.attributeSelection.ASEvaluation;
+import weka.attributeSelection.AttributeSelection;
+import weka.attributeSelection.InfoGainAttributeEval;
+import weka.attributeSelection.Ranker;
+import weka.classifiers.Classifier;
+import weka.classifiers.bayes.NaiveBayesMultinomial;
+import weka.core.Instances;
+import weka.filters.Filter;
+import weka.filters.unsupervised.attribute.Remove;
+
+import javax.annotation.Nullable;
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Train a Weka model to classify documents according to symptom severity
+ * Created for the 2016 i2b2 NLP Shared Task
+ *
+ * Created by gpfinley on 7/28/16.
+ */
+@ProcessorScoped
+public class SeverityClassifierTrainer implements CollectionProcessor {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SeverityClassifierTrainer.class);
+
+    private final Path outPath;
+    private final TextWekaProcessor wekaProcessor;
+    private final int ATTRIBUTES_TO_KEEP = 1000;
+    private final int MIN_WORD_COUNT = 2;
+
+    /**
+     * Initialize this trainer. If the stopwords file is not present or can't be read from, trainer will still work
+     * @param outPath the path to write the model to
+     * @param stopWordsPath path to a stopwords file
+     * @throws BiomedicusException
+     */
+    @Inject
+    public SeverityClassifierTrainer(@Setting("docclass.severity.output.path") Path outPath, @Setting("docclass.stopwords.path") @Nullable Path stopWordsPath) throws BiomedicusException {
+        Set<String> stopWords = null;
+        if(stopWordsPath != null) {
+            try {
+                List<String> stopWordsList = Files.readAllLines(stopWordsPath);
+                stopWords = new HashSet<>(stopWordsList);
+            } catch (IOException e) {
+                LOGGER.warn("Could not load stopwords file; will not exclude stopwords");
+            }
+        }
+        this.outPath = outPath;
+        wekaProcessor = new SeverityWekaProcessor(stopWords, MIN_WORD_COUNT, true);
+    }
+
+    /**
+     * Add the document to the collection, which will be trained all at once at the end
+     * @param document a document
+     */
+    @Override
+    public void processDocument(Document document) {
+        wekaProcessor.addTrainingDocument(document);
+    }
+
+    /**
+     * Do training after all documents have been passed
+     * Uses Weka's attribute selection and classifier libraries
+     */
+    @Override
+    public void allDocumentsProcessed() throws BiomedicusException {
+
+        Instances trainSet = wekaProcessor.getTrainingData();
+        Classifier classifier = new NaiveBayesMultinomial();
+        AttributeSelection sel = new AttributeSelection();
+        ASEvaluation infogain = new InfoGainAttributeEval();
+        Ranker ranker = new Ranker();
+        Remove remove = new Remove();
+
+        ranker.setNumToSelect(ATTRIBUTES_TO_KEEP);
+        sel.setEvaluator(infogain);
+        sel.setSearch(ranker);
+
+        try {
+            sel.SelectAttributes(trainSet);
+            int[] selected = sel.selectedAttributes();
+            remove.setInvertSelection(true);
+            remove.setAttributeIndicesArray(selected);
+            remove.setInputFormat(trainSet);
+            trainSet = Filter.useFilter(trainSet, remove);
+            classifier.buildClassifier(trainSet);
+        } catch (Exception e) {
+            throw new BiomedicusException();
+        }
+
+        DocumentClassifierModel model = new SeverityClassifierModel(classifier, remove, wekaProcessor);
+
+        try {
+            ObjectOutputStream oos = new ObjectOutputStream(new FileOutputStream(outPath.toFile()));
+            oos.writeObject(model);
+            oos.close();
+        } catch(IOException e) {
+            throw new BiomedicusException();
+        }
+    }
+
+}

--- a/biomedicus-core/src/main/java/edu/umn/biomedicus/docclass/SeverityWekaProcessor.java
+++ b/biomedicus-core/src/main/java/edu/umn/biomedicus/docclass/SeverityWekaProcessor.java
@@ -1,0 +1,298 @@
+package edu.umn.biomedicus.docclass;
+
+import edu.umn.biomedicus.common.text.Document;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import weka.core.*;
+
+import javax.annotation.Nullable;
+import java.io.Serializable;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Text processing used for the symptom severity annotator, as written for the 2016 i2b2 NLP Shared Task
+ * Currently works on raw document text; could be modified to work on richer data (i.e., biomedicus's NLP results)
+ *
+ * Created by gpfinley on 8/4/16.
+ */
+public class SeverityWekaProcessor implements TextWekaProcessor, Serializable {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SeverityWekaProcessor.class);
+
+    // Build this incrementally with each added document
+    private Instances trainingTextInstances;
+
+    private final boolean sortWordsByDescendingFreq;
+    private final int minTermCount;
+    private final Set<String> stopWords;
+    private Map<String, Integer> dictionary;
+
+    // Empty Instances objects used to maintain consistent format between individual Instance objects
+    private Instances textTemplate;
+    private Instances vectorTemplate;
+    private final Attribute classAttribute;
+
+    // Created specifically for the i2b2-format XML files
+    private final Pattern fileTextPattern = Pattern.compile("\\|(.*)\\[report_end\\]", Pattern.DOTALL);
+    private final Pattern scorePattern = Pattern.compile("score=\"(\\w+)\"");
+    private final Pattern annotatedBy = Pattern.compile("annotated_by=\"(.)\"");
+
+    /**
+     * Initialize this processor
+     * @param stopWords an optional set of words to exclude from the vector space
+     * @param minTermCount minimum number of occurrences to use a term in the vector space (2 is a good value)
+     * @param sortWordsByDescendingFreq whether to sort words by global frequency (this helps attribute selection)
+     */
+    public SeverityWekaProcessor(@Nullable Set<String> stopWords, int minTermCount, boolean sortWordsByDescendingFreq) {
+        this.stopWords = stopWords == null ? new HashSet<>() : stopWords;
+        this.sortWordsByDescendingFreq = sortWordsByDescendingFreq;
+        this.minTermCount = minTermCount;
+
+        ArrayList<Attribute> textInstanceAttributes = new ArrayList<>();
+        List<String> classValues = Arrays.asList("ABSENT", "MILD", "MODERATE", "SEVERE", SeverityClassifierModel.UNK);
+        classAttribute = new Attribute("_class", classValues);
+        textInstanceAttributes.add(classAttribute);
+        textInstanceAttributes.add(new Attribute("text", (List<String>) null));
+
+        textTemplate = new Instances("textTemplate", textInstanceAttributes, 0);
+        textTemplate.setClassIndex(0);
+
+        trainingTextInstances = new Instances(textTemplate);
+    }
+
+    /**
+     * Once all documents have been passed, vectorize the text and return the real-valued feature vectors
+     * @return Instances containing all training data
+     */
+    @Override
+    public Instances getTrainingData() {
+        buildDictionary(trainingTextInstances);
+        return vectorizeInstances(trainingTextInstances);
+    }
+
+    /**
+     * Add a document for training. Will extract this doc's text but will not train on it until getTrainingData called
+     * @param document a document
+     */
+    @Override
+    public void addTrainingDocument(Document document) {
+        Instance trainingInstance = getTextInstance(document.getText());
+        if (trainingInstance != null) {
+            trainingTextInstances.add(trainingInstance);
+        }
+    }
+
+    /**
+     * Convert a document into a vector instance. buildDictionary() needs to have been run.
+     * @param document a document
+     * @return an Instance with real-valued data
+     */
+    @Override
+    public Instance getTestData(Document document) {
+        Instance textInstance = getTextInstance(document.getText());
+        Instance vectorInstance = vectorizeInstance(textInstance);
+        vectorInstance.setDataset(vectorTemplate);
+        return vectorInstance;
+    }
+
+    /**
+     * Process the text and class of this document and put it into an Instance
+     * @param docText raw text from the file (assumed XML format)
+     * @return an Instance with two attributes: class, and doctext
+     */
+    @Nullable
+    private Instance getTextInstance(String docText) {
+        String fileText;
+        String docClass;
+        Matcher matcher = fileTextPattern.matcher(docText);
+        if(matcher.find()) {
+            fileText = matcher.group(1);
+        } else {
+            fileText = docText;
+        }
+        fileText = processText(fileText);
+        matcher = scorePattern.matcher(docText);
+        if(matcher.find()) {
+            docClass = matcher.group(1);
+        } else {
+            docClass = SeverityClassifierModel.UNK;
+            if(dictionary == null) {
+                LOGGER.warn("Added document with unknown class during training; will ignore!");
+                return null;
+            }
+        }
+        // add the annotator as a word (this helps classification a little)
+        matcher = annotatedBy.matcher(docText);
+        if(matcher.find()) {
+            fileText += " thisNoteAnnotatedBy" + matcher.group(1);
+        }
+
+        Instance inst = new DenseInstance(2);
+        inst.setDataset(textTemplate);
+        inst.setValue(0, docClass);
+        inst.attribute(1).addStringValue(fileText);
+        inst.setValue(1, fileText);
+        return inst;
+    }
+
+    /**
+     * Prepare text for vectorization (lowercasing, fixing bad line breaks, rough tokenization)
+     * @param origText entire text of a document
+     * @return the processed text
+     */
+    private String processText(String origText) {
+        String text = fixTableRows(origText);
+        text = text.toLowerCase();
+        String[] words = text.split("\\W+");
+        if(words.length > 0) {
+            StringBuilder builder = new StringBuilder();
+            builder.append(words[0]);
+            for (int i = 1; i < words.length; i++) {
+                builder.append(" ");
+                builder.append(words[i]);
+            }
+            addBigrams(words, builder);
+            return builder.toString();
+        } else {
+            LOGGER.warn("Empty document");
+            return "";
+        }
+    }
+    /**
+     * Given a list of words and a StringBuilder, continue to build bigrams/trigrams/etc. onto the builder
+     * @param words array of words in their natural order
+     * @param builder an active StringBuilder
+     */
+    private void addBigrams(String[] words, StringBuilder builder) {
+        for(int i=1; i<words.length; i++) {
+            builder.append(" ");
+            builder.append(words[i-1]);
+            builder.append("_");
+            builder.append(words[i]);
+        }
+    }
+
+    /**
+     * Fixes a problem common in the i2b2 text: sometimes new table lines start without any whitespace
+     * @param origText text with table problems
+     * @return text with line breaks inserted
+     */
+    private String fixTableRows(String origText) {
+        String pattern = "(:.*)\n+(.*[^A-Z\\-\\( \\s/])([A-Z].*:)";
+        String repl = "$1 $2\n$3";
+        // have to run this a few times to be sure we get it all (adjacent ones won't both be matched)
+        String fixed = origText.replaceAll(pattern, repl);
+        fixed = fixed.replaceAll(pattern, repl);
+        fixed = fixed.replaceAll(pattern, repl);
+        return fixed;
+    }
+
+    /**
+     * Builds a dictionary from known text and set the attributes for vector instances
+     * In current implementation, this is done all at once, not incrementally, since total word counts must be known
+     * This function must be called before vectorizing any text instances
+     * @param textInstances Instances containing text (whitespace-delimited words)
+     */
+    private void buildDictionary(Instances textInstances) {
+        Map<String, Integer> globalCounts = new LinkedHashMap<>();
+        for (Instance inst : textInstances) {
+            String processed = inst.stringValue(1);
+            String[] words = processed.split("\\s+");
+            for (int i = 0; i < words.length; i++) {
+                String uni = words[i];
+                if (!stopWords.contains(uni)) {
+                    if (!globalCounts.containsKey(uni)) {
+                        globalCounts.put(uni, 0);
+                    }
+                    globalCounts.put(uni, globalCounts.get(uni) + 1);
+                }
+            }
+        }
+        List<String> sortedWords = new ArrayList<>();
+        sortedWords.addAll(globalCounts.keySet());
+        if (sortWordsByDescendingFreq) {
+            sortedWords.sort(new ByValue<>(globalCounts, true));
+        }
+        dictionary = new HashMap<>();
+        ArrayList<Attribute> vectorInstanceAttributes = new ArrayList<>();
+        vectorInstanceAttributes.add(classAttribute);
+        for (String word : sortedWords) {
+            if (globalCounts.get(word) >= minTermCount) {
+                dictionary.put(word, dictionary.size());
+                vectorInstanceAttributes.add(new Attribute(word));
+            }
+        }
+        vectorTemplate = new Instances("vectorTemplate", vectorInstanceAttributes, 0);
+        vectorTemplate.setClassIndex(0);
+    }
+
+    /**
+     * Vectorize a bunch of text instances and put them into a single Instances object, probably to train a classifier
+     * @param textInstances Instances that have a class and text attribute
+     * @return Instances that have a class and many real-valued attributes
+     */
+    private Instances vectorizeInstances(Instances textInstances) {
+        List<Instance> listInstance = new ArrayList<>();
+        for(Instance textInstance : textInstances) {
+            listInstance.add(vectorizeInstance(textInstance));
+        }
+        Instances vectorized = new Instances(vectorTemplate, textInstances.numInstances());
+        for(Instance inst : listInstance) vectorized.add(inst);
+        return vectorized;
+    }
+
+    /**
+     * Vectorize a text instance, probably for a classifier to evaluate
+     * @param textInstance Instance that has a class and text attribute
+     * @return Instance that has a class and many real-valued attributes
+     */
+    public Instance vectorizeInstance(Instance textInstance) {
+        // Put the class and word counts for this doc into an array, then build an Instance from that
+        // counts[0] is the doc class, not actually a word count
+        double[] counts = new double[dictionary.size() + 1];
+        counts[0] = textInstance.classValue();
+        String processed = textInstance.stringValue(1);
+        String[] words = processed.split("\\s+");
+        for(int i=0; i<words.length; i++) {
+            String uni = words[i];
+            if(!stopWords.contains(uni) && dictionary.containsKey(uni)) {
+                counts[dictionary.get(uni)+1]++;
+            }
+        }
+        return new SparseInstance(1, counts);
+    }
+
+    /**
+     * General-use Comparator for sorting based on comparable map values
+     * Will fall back to comparing keys if they are comparable and the values are equivalent
+     * Created by gpfinley on 3/1/16.
+     */
+    public class ByValue<K, V extends Comparable<V>> implements Comparator<K> {
+        private final Map<K, V> map;
+        private final boolean reverse;
+
+        public ByValue(Map<K, V> map) {
+            this(map, false);
+        }
+
+        public ByValue(Map<K, V> map, boolean reverse) {
+            this.map = map;
+            this.reverse = reverse;
+        }
+
+        public int compare(K o1, K o2) {
+            int cmp = map.get(o1).compareTo(map.get(o2));
+            if(cmp == 0) {
+                // Is there a way to be sure that K is Comparable<K>?
+                if(o1 instanceof Comparable) {
+                    cmp = ((Comparable<K>) o1).compareTo(o2);
+                }
+            }
+            if(reverse) return -cmp;
+            return cmp;
+        }
+    }
+
+}

--- a/biomedicus-core/src/main/java/edu/umn/biomedicus/docclass/TextInstanceProcessor.java
+++ b/biomedicus-core/src/main/java/edu/umn/biomedicus/docclass/TextInstanceProcessor.java
@@ -1,0 +1,7 @@
+package edu.umn.biomedicus.docclass;
+
+/**
+ * Created by gpfinley on 8/4/16.
+ */
+public interface TextInstanceProcessor {
+}

--- a/biomedicus-core/src/main/java/edu/umn/biomedicus/docclass/TextInstanceProcessor.java
+++ b/biomedicus-core/src/main/java/edu/umn/biomedicus/docclass/TextInstanceProcessor.java
@@ -1,7 +1,0 @@
-package edu.umn.biomedicus.docclass;
-
-/**
- * Created by gpfinley on 8/4/16.
- */
-public interface TextInstanceProcessor {
-}

--- a/biomedicus-core/src/main/java/edu/umn/biomedicus/docclass/TextWekaProcessor.java
+++ b/biomedicus-core/src/main/java/edu/umn/biomedicus/docclass/TextWekaProcessor.java
@@ -1,0 +1,32 @@
+package edu.umn.biomedicus.docclass;
+
+import edu.umn.biomedicus.common.text.Document;
+import weka.core.Instance;
+import weka.core.Instances;
+
+/**
+ * Interface for converting documents to Weka Instance objects
+ *
+ * Created by gpfinley on 8/4/16.
+ */
+public interface TextWekaProcessor {
+
+    /**
+     * Pass in a document for training
+     * @param document a single document
+     */
+    void addTrainingDocument(Document document);
+
+    /**
+     * Call this after adding all documents(to build a text model, etc.)
+     * @return an Instances object containing all training data
+     */
+    Instances getTrainingData();
+
+    /**
+     * Probably used at test time
+     * @param document a single document to classify
+     * @return an Instance to pass to a classifier
+     */
+    Instance getTestData(Document document);
+}

--- a/distribution/src/main/resources/config/biomedicusConfiguration.yml
+++ b/distribution/src/main/resources/config/biomedicusConfiguration.yml
@@ -31,6 +31,12 @@ settings:
         outputDir.path: /path-to
     senseMap.path: acronym/senseMap.ser
     orthographicModel.path: acronym-orthographic/orthographicModel.yml
+  docclass:
+    model: severity
+    severity:
+      model.path: docclass/SeverityClassifierModel.ser
+      output.path: docclass/SeverityClassifierModel.ser
+    stopwords.path: do_not_use
   semanticNetwork:
     srdef.path: semnetwork/SRDEF
     semgroups.path: semnetwork/SemGroups.txt
@@ -58,6 +64,7 @@ settings:
 settingInterfaces:
   parser.implementation: edu.umn.biomedicus.parsing.Parser
   acronym.model: edu.umn.biomedicus.acronym.AcronymModel
+  docclass.model: edu.umn.biomedicus.docclass.DocumentClassifierModel
   socialhistory.parser: edu.umn.biomedicus.parsing.Parser
 # these indicate the options for the bindings above
 interfaceImplementations:
@@ -65,3 +72,5 @@ interfaceImplementations:
     opennlp: edu.umn.biomedicus.opennlp.OpenNlpParser
   edu.umn.biomedicus.acronym.AcronymModel:
     vector: edu.umn.biomedicus.acronym.AcronymVectorModel
+  edu.umn.biomedicus.docclass.DocumentClassifierModel:
+    severity: edu.umn.biomedicus.docclass.SeverityClassifierModel

--- a/distribution/src/main/resources/desc/ae/SeverityClassifierPipeline.xml
+++ b/distribution/src/main/resources/desc/ae/SeverityClassifierPipeline.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2016 Regents of the University of Minnesota.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<analysisEngineDescription xmlns="http://uima.apache.org/resourceSpecifier">
+    <frameworkImplementation>org.apache.uima.java</frameworkImplementation>
+    <primitive>false</primitive>
+    <delegateAnalysisEngineSpecifiers>
+        <delegateAnalysisEngine key="docclass">
+            <import location="annotator/DocumentClassifier.xml"/>
+        </delegateAnalysisEngine>
+    </delegateAnalysisEngineSpecifiers>
+    <analysisEngineMetaData>
+        <name>BioMedICUS Severity Classification Pipeline</name>
+        <version>${project.version}</version>
+        <vendor>${organization.name}</vendor>
+        <flowConstraints>
+            <fixedFlow>
+                <node>docclass</node>
+            </fixedFlow>
+        </flowConstraints>
+        <capabilities>
+            <capability>
+                <inputSofas>
+                    <sofaName>SystemView</sofaName>
+                </inputSofas>
+                <outputSofas>
+                    <sofaName>SystemView</sofaName>
+                </outputSofas>
+            </capability>
+        </capabilities>
+        <operationalProperties>
+            <modifiesCas>true</modifiesCas>
+            <multipleDeploymentAllowed>true</multipleDeploymentAllowed>
+            <outputsNewCASes>false</outputsNewCASes>
+        </operationalProperties>
+    </analysisEngineMetaData>
+
+    <resourceManagerConfiguration>
+        <externalResources>
+            <externalResource>
+                <name>guiceInjector</name>
+                <description>The guice resource.</description>
+                <customResourceSpecifier>
+                    <resourceClassName>edu.umn.biomedicus.uima.adapter.GuiceInjector</resourceClassName>
+                </customResourceSpecifier>
+            </externalResource>
+        </externalResources>
+    </resourceManagerConfiguration>
+</analysisEngineDescription>

--- a/distribution/src/main/resources/desc/ae/SeverityTrainingPipeline.xml
+++ b/distribution/src/main/resources/desc/ae/SeverityTrainingPipeline.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2016 Regents of the University of Minnesota.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<analysisEngineDescription xmlns="http://uima.apache.org/resourceSpecifier">
+    <frameworkImplementation>org.apache.uima.java</frameworkImplementation>
+    <primitive>false</primitive>
+    <delegateAnalysisEngineSpecifiers>
+        <delegateAnalysisEngine key="trainer">
+            <import location="training/SeverityClassifierTrainer.xml"/>
+        </delegateAnalysisEngine>
+    </delegateAnalysisEngineSpecifiers>
+    <analysisEngineMetaData>
+        <name>BioMedICUS Severity Classification Training Pipeline</name>
+        <version>${project.version}</version>
+        <vendor>${organization.name}</vendor>
+        <flowConstraints>
+            <fixedFlow>
+                <node>trainer</node>
+            </fixedFlow>
+        </flowConstraints>
+        <capabilities>
+            <capability>
+                <inputSofas>
+                    <sofaName>SystemView</sofaName>
+                </inputSofas>
+                <outputSofas>
+                    <sofaName>SystemView</sofaName>
+                </outputSofas>
+            </capability>
+        </capabilities>
+        <operationalProperties>
+            <modifiesCas>true</modifiesCas>
+            <multipleDeploymentAllowed>true</multipleDeploymentAllowed>
+            <outputsNewCASes>false</outputsNewCASes>
+        </operationalProperties>
+    </analysisEngineMetaData>
+
+    <resourceManagerConfiguration>
+        <externalResources>
+            <externalResource>
+                <name>guiceInjector</name>
+                <description>The guice resource.</description>
+                <customResourceSpecifier>
+                    <resourceClassName>edu.umn.biomedicus.uima.adapter.GuiceInjector</resourceClassName>
+                </customResourceSpecifier>
+            </externalResource>
+        </externalResources>
+    </resourceManagerConfiguration>
+</analysisEngineDescription>

--- a/distribution/src/main/resources/desc/ae/annotator/SeverityClassifier.xml
+++ b/distribution/src/main/resources/desc/ae/annotator/SeverityClassifier.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2016 Regents of the University of Minnesota.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<analysisEngineDescription xmlns="http://uima.apache.org/resourceSpecifier">
+    <frameworkImplementation>org.apache.uima.java</frameworkImplementation>
+    <primitive>true</primitive>
+    <annotatorImplementationName>edu.umn.biomedicus.uima.adapter.CollectionProcessorAnnotator</annotatorImplementationName>
+    <analysisEngineMetaData>
+        <name>Severity Classifier</name>
+        <description>Classifies documents for symptom severity.</description>
+        <version>${project.version}</version>
+        <vendor>${organization.name}</vendor>
+        <configurationParameters>
+            <configurationParameter>
+                <name>collectionProcessor</name>
+                <type>String</type>
+            </configurationParameter>
+            <configurationParameter>
+                <name>documentProcessor</name>
+                <description>The document processor class to instantiate.</description>
+                <type>String</type>
+                <mandatory>true</mandatory>
+            </configurationParameter>
+            <configurationParameter>
+                <name>viewName</name>
+                <description>The name of the UIMA view to use.</description>
+                <type>String</type>
+            </configurationParameter>
+            <configurationParameter>
+                <name>eagerLoad</name>
+                <description>
+                    The name of any classes that need to be eagerly loaded by the Guice injector. Classes which are
+                    instances of LoadableDataModel will have the loadData method called.
+                </description>
+                <type>String</type>
+                <multiValued>true</multiValued>
+                <mandatory>false</mandatory>
+            </configurationParameter>
+        </configurationParameters>
+        <configurationParameterSettings>
+            <nameValuePair>
+                <name>collectionProcessor</name>
+                <value>
+                    <string>edu.umn.biomedicus.application.DocumentProcessorRunner</string>
+                </value>
+            </nameValuePair>
+            <nameValuePair>
+                <name>documentProcessor</name>
+                <value>
+                    <string>edu.umn.biomedicus.docclass.DocumentClassifier</string>
+                </value>
+            </nameValuePair>
+            <nameValuePair>
+                <name>viewName</name>
+                <value>
+                    <string>SystemView</string>
+                </value>
+            </nameValuePair>
+            <nameValuePair>
+                <name>eagerLoad</name>
+                <value>
+                    <array>
+                        <string>edu.umn.biomedicus.docclass.SeverityClassifierModel</string>
+                    </array>
+                </value>
+            </nameValuePair>
+        </configurationParameterSettings>
+        <typeSystemDescription>
+            <imports>
+                <import name="edu.umn.biomedicus.types.TypeSystem"/>
+            </imports>
+        </typeSystemDescription>
+        <typePriorities>
+            <imports>
+                <import name="edu.umn.biomedicus.types.TypeSystemTypePriorities"/>
+            </imports>
+        </typePriorities>
+        <operationalProperties>
+            <modifiesCas>true</modifiesCas>
+            <multipleDeploymentAllowed>true</multipleDeploymentAllowed>
+            <outputsNewCASes>false</outputsNewCASes>
+        </operationalProperties>
+    </analysisEngineMetaData>
+
+    <externalResourceDependencies>
+        <externalResourceDependency>
+            <key>guiceInjector</key>
+            <description>The guice injector resource.</description>
+        </externalResourceDependency>
+    </externalResourceDependencies>
+
+    <resourceManagerConfiguration>
+        <externalResources>
+            <externalResource>
+                <name>guiceInjector</name>
+                <description>The guice resource.</description>
+                <customResourceSpecifier>
+                    <resourceClassName>edu.umn.biomedicus.uima.adapter.GuiceInjector</resourceClassName>
+                </customResourceSpecifier>
+            </externalResource>
+        </externalResources>
+        <externalResourceBindings>
+            <externalResourceBinding>
+                <key>guiceInjector</key>
+                <resourceName>guiceInjector</resourceName>
+            </externalResourceBinding>
+        </externalResourceBindings>
+    </resourceManagerConfiguration>
+</analysisEngineDescription>
+

--- a/distribution/src/main/resources/desc/ae/training/SeverityClassifierTrainer.xml
+++ b/distribution/src/main/resources/desc/ae/training/SeverityClassifierTrainer.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2016 Regents of the University of Minnesota.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<analysisEngineDescription xmlns="http://uima.apache.org/resourceSpecifier">
+    <frameworkImplementation>org.apache.uima.java</frameworkImplementation>
+    <primitive>true</primitive>
+    <annotatorImplementationName>edu.umn.biomedicus.uima.adapter.CollectionProcessorAnnotator</annotatorImplementationName>
+    <analysisEngineMetaData>
+        <name>Severity Document Classifier Trainer</name>
+        <description>Training for the severity document classifier.</description>
+        <version>${project.version}</version>
+        <vendor>${organization.name}</vendor>
+        <configurationParameters>
+            <configurationParameter>
+                <name>docclass.model.path</name>
+                <type>String</type>
+            </configurationParameter>
+            <configurationParameter>
+                <name>docclass.stopwords.path</name>
+                <type>String</type>
+            </configurationParameter>
+            <configurationParameter>
+                <name>collectionProcessor</name>
+                <type>String</type>
+            </configurationParameter>
+            <configurationParameter>
+                <name>viewName</name>
+                <description>The name of the UIMA view to use.</description>
+                <type>String</type>
+            </configurationParameter>
+            <configurationParameter>
+                <name>eagerLoad</name>
+                <description>
+                    The name of any classes that need to be eagerly loaded by the Guice injector. Classes which are
+                    instances of LoadableDataModel will have the loadData method called.
+                </description>
+                <type>String</type>
+                <multiValued>true</multiValued>
+                <mandatory>false</mandatory>
+            </configurationParameter>
+            <configurationParameter>
+                <name>postProcessors</name>
+                <description>
+                    The class names of any post processors that should be run after all documents have been processed.
+                </description>
+                <type>String</type>
+                <multiValued>true</multiValued>
+                <mandatory>false</mandatory>
+            </configurationParameter>
+        </configurationParameters>
+        <configurationParameterSettings>
+            <nameValuePair>
+                <name>collectionProcessor</name>
+                <value>
+                    <string>edu.umn.biomedicus.docclass.SeverityClassifierTrainer</string>
+                </value>
+            </nameValuePair>
+            <nameValuePair>
+                <name>viewName</name>
+                <value>
+                    <string>SystemView</string>
+                </value>
+            </nameValuePair>
+        </configurationParameterSettings>
+        <typeSystemDescription>
+            <imports>
+                <import name="edu.umn.biomedicus.types.TypeSystem"/>
+            </imports>
+        </typeSystemDescription>
+        <typePriorities>
+            <imports>
+                <import name="edu.umn.biomedicus.types.TypeSystemTypePriorities"/>
+            </imports>
+        </typePriorities>
+        <operationalProperties>
+            <modifiesCas>true</modifiesCas>
+            <multipleDeploymentAllowed>true</multipleDeploymentAllowed>
+            <outputsNewCASes>false</outputsNewCASes>
+        </operationalProperties>
+    </analysisEngineMetaData>
+
+    <externalResourceDependencies>
+        <externalResourceDependency>
+            <key>guiceInjector</key>
+            <description>The guice injector resource.</description>
+        </externalResourceDependency>
+    </externalResourceDependencies>
+
+    <resourceManagerConfiguration>
+        <externalResources>
+            <externalResource>
+                <name>guiceInjector</name>
+                <description>The guice resource.</description>
+                <customResourceSpecifier>
+                    <resourceClassName>edu.umn.biomedicus.uima.adapter.GuiceInjector</resourceClassName>
+                </customResourceSpecifier>
+            </externalResource>
+        </externalResources>
+        <externalResourceBindings>
+            <externalResourceBinding>
+                <key>guiceInjector</key>
+                <resourceName>guiceInjector</resourceName>
+            </externalResourceBinding>
+        </externalResourceBindings>
+    </resourceManagerConfiguration>
+</analysisEngineDescription>


### PR DESCRIPTION
Added capabilities for:

1) generic whole-document classification,
2) doing so for any domain using Weka, and
3) doing so specifically for symptom severity (shared task)

This type of annotator stores a value in Document metadata, so multiple DocumentClassifiers can be run for different domains (every class implementing the DocumentClassifier interface must specify a metadata key).

The symptom severity classifier doesn't currently use any of biomedicus's processing; it does all its NLP from scratch. It is set up this way so that it could replicate my experiments. I think it would make sense to remove some of its capabilities and rely on biomedicus's (tokenization, normalization, document vectorization, XML parsing, etc.) in the future, especially if using it for real tasks with more training data.

Also includes two dummy pipelines (one for training, one for annotation) that are useful for the immediate task but probably don't need to be included with master.

NB: makes new use of biomedicus data, where the folder docclass will need to be added.
